### PR TITLE
Fixes for LDAP auth

### DIFF
--- a/templates/91-local.py.epp
+++ b/templates/91-local.py.epp
@@ -10,7 +10,7 @@ ALLOWED_HOSTS = ['<%= $subdomain %>.<%= $domain_name%>', '127.0.0.1', 'localhost
 CSRF_TRUSTED_ORIGINS = [BASE_URL.strip('/')]
 
 AUTH_LDAP_SERVER_URI = 'ldaps://ipa.int.<%= $domain_name %>/'
-AUTH_LDAP_BIND_DN = 'uid=admin,cn=users,cn=accounts,<%= $base_dn %>',
+AUTH_LDAP_BIND_DN = 'uid=admin,cn=users,cn=accounts,<%= $base_dn %>'
 AUTH_LDAP_BIND_PASSWORD = '<%= $ldap_password %>'
 AUTH_LDAP_USER_DN_TEMPLATE = "uid=%(user)s,cn=users,cn=accounts,<%= $base_dn %>"
 

--- a/templates/92-local_ldap.py.epp
+++ b/templates/92-local_ldap.py.epp
@@ -1,2 +1,4 @@
-AUTHENTICATION_BACKENDS += ['django_auth_ldap.backend.LDAPBackend']
+AUTHENTICATION_BACKENDS += ['userportal.authentication.staffLdapBackend']
 LOGIN_URL = '/accounts/login/' # So it does not use SAML2
+LDAP_CONFIG['required_access_attributes'] = REQUIRED_ACCESS_ATTRIBUTES
+LDAP_CONFIG['staff_attributes'] = STAFF_ATTRIBUTES


### PR DESCRIPTION
* AUTH_LDAP_BIND_DN must be a string, not a tuple
* use the staffLdapBackend and implement staff and access attributes for LDAP auth

With this, one can use the `memberof` attribute with values such as `cn=admins,cn=groups,cn=accounts,dc=int,dc=test-mc-infra-cours-beluga,dc=calculquebec,dc=cloud` to grant staff access to the portal